### PR TITLE
Add travis hook support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,9 @@ var server = http.createServer(function (request, response) {
             return;
         }
 
-        var ref = body.ref;
+        // Github hooks report the branch name in body.ref.
+        // Travis hooks report the banch name in body.branch.
+        var ref = body.ref || body.branch;
         if (typeof ref === 'undefined') {
             console.error('Invalid post:');
             console.trace(new Error(body));


### PR DESCRIPTION
This small change allows gitfish to listen to webhooks from travis as well.  Nice for when you only want to do a pull after travis-ci says it's green.

http://docs.travis-ci.com/user/notifications/#Webhook-notification
